### PR TITLE
feat: onboarding flow implemented

### DIFF
--- a/packages/nextjs/components/pending-quests.tsx
+++ b/packages/nextjs/components/pending-quests.tsx
@@ -15,18 +15,25 @@ export function PendingQuests({ userAddress }: PendingQuestsProps) {
   const [user, setUser] = useState<User | null>(null);
   const [pendingQuests, setPendingQuests] = useState<Quest[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [defaultQuest, setDefaultQuest] = useState<Quest | null>(null);
 
   useEffect(() => {
     const fetchData = async () => {
       try {
         const userData = await getUser(userAddress);
-        const userQuestData = userData?.quests as { pending: string[]; completed: string[] };
         setUser(userData);
-        if (userData) {
-          const allQuests = await getQuests();
-          const userPendingQuests = allQuests.filter(quest => userQuestData.pending.includes(quest.id));
-          setPendingQuests(userPendingQuests);
+
+        const allQuests = await getQuests();
+
+        if (!userData) {
+          const firstQuest = allQuests.find(quest => quest.id === "8e03aa6d-baf1-413e-8243-3487c64ee95d") || null;
+          setDefaultQuest(firstQuest);
+          return;
         }
+
+        const userQuestData = userData?.quests as { pending: string[]; completed: string[] };
+        const userPendingQuests = allQuests.filter(quest => userQuestData.pending.includes(quest.id));
+        setPendingQuests(userPendingQuests);
       } catch (error) {
         console.error("Error fetching user data or quests:", error);
       } finally {
@@ -45,7 +52,19 @@ export function PendingQuests({ userAddress }: PendingQuestsProps) {
     );
   }
 
-  if (!user || pendingQuests.length === 0) {
+  if (!user && defaultQuest) {    
+    return <p className="text-center text-gray-500"><QuestCard
+    isCompleted={false}
+    key={'8e03aa6d-baf1-413e-8243-3487c64ee95d'}
+    quest={defaultQuest}
+    onClick={() => {
+      /* TODO: Implement quest start logic */
+    }}
+  /></p>;
+  }
+
+  if (pendingQuests.length === 0) {
+    console.log(user, 'user')
     return <p className="text-center text-gray-500">No pending quests available.</p>;
   }
 

--- a/packages/nextjs/src/actions/userActions.ts
+++ b/packages/nextjs/src/actions/userActions.ts
@@ -3,6 +3,7 @@
 import { db } from "../db/drizzle";
 import { users } from "../db/schema";
 import { eq } from "drizzle-orm";
+import type { Quest } from "../db/schema";
 
 // TODO: Decide where to place type, nullable stuff
 export type TEMPORARY_User = {
@@ -18,12 +19,17 @@ export type TEMPORARY_User = {
   lastQuestCompletedAt?: Date | null; // Optional timestamp for the last quest completed
 };
 
+const DEFAULT_QUEST = {
+  pending: [],
+  completed: ["8e03aa6d-baf1-413e-8243-3487c64ee95d"],
+};
+
 export default async function addUser(address: string) {
   // TODO: update quests to be an array of quest ids
   return (
     await db
       .insert(users)
-      .values({ address: address, quests: { pending: [], completed: [] } })
+      .values({ address: address, quests: DEFAULT_QUEST})
       .returning()
   )[0];
 }


### PR DESCRIPTION
Current flow: user is created in DB after user attempts to upload an image. 

Therefore:
- when user uploads image, 'onboarding quest' is automatically added to 'completed' array, at the same time user DB entry is created.  
- before user is created (when app initially renders), default quest is retrieved from DB and rendered to user.
- note: the 'onboarding quest' is never added to the pending quest array for the user.